### PR TITLE
[REFACTOR] refactor: 카테고리 API 구조 변경

### DIFF
--- a/src/firebase/firebaseCategory.ts
+++ b/src/firebase/firebaseCategory.ts
@@ -1,18 +1,26 @@
-import { addDoc, collection, getDocs } from "firebase/firestore";
+import {
+  addDoc,
+  collection,
+  doc,
+  getDocs,
+  serverTimestamp,
+} from "firebase/firestore";
 import { database } from "../config/firebaseConfig";
 
 export const addCategory = async (
-  userId: string,
+  userId: number,
   categoryName: string,
-  color: string
+  textColor: string
 ) => {
   try {
-    const docRef = await addDoc(collection(database, "category"), {
-      userId,
-      categoryName,
-      color,
-      createdAt: new Date(),
-    });
+    const docRef = await addDoc(
+      collection(doc(database, "categories", userId.toString()), "category"),
+      {
+        categoryName,
+        textColor,
+        createdAt: serverTimestamp(),
+      }
+    );
 
     return docRef.id;
   } catch (error) {
@@ -20,9 +28,11 @@ export const addCategory = async (
   }
 };
 
-export const getCategories = async () => {
+export const getCategories = async (userId: number) => {
   try {
-    const querySnapshot = await getDocs(collection(database, "category"));
+    const querySnapshot = await getDocs(
+      collection(doc(database, "categories", userId.toString()), "category")
+    );
     const categories = querySnapshot.docs.map((doc) => ({
       id: doc.id,
       ...doc.data(),

--- a/src/firebase/firebaseLetter.ts
+++ b/src/firebase/firebaseLetter.ts
@@ -8,14 +8,14 @@ import {
 } from "firebase/firestore";
 
 // 편지 등록 함수
-export const addLetter = async (user_id: number, content: string) => {
+export const addLetter = async (userId: number, content: string) => {
   try {
     const docRef = await addDoc(
-      collection(doc(database, "letters", user_id.toString()), "posts"),
+      collection(doc(database, "letters", userId.toString()), "posts"),
       {
         content,
         is_read: false,
-        created_at: serverTimestamp(),
+        createdAt: serverTimestamp(),
       }
     );
 
@@ -26,10 +26,10 @@ export const addLetter = async (user_id: number, content: string) => {
 };
 
 // 편지 조회 함수
-export const getLetters = async (user_id: number) => {
+export const getLetters = async (userId: number) => {
   try {
     const querySnapshot = await getDocs(
-      collection(doc(database, "letters", user_id.toString()), "posts")
+      collection(doc(database, "letters", userId.toString()), "posts")
     );
     const letters = querySnapshot.docs.map((doc) => ({
       id: doc.id,

--- a/src/firebase/firebaseReflect.ts
+++ b/src/firebase/firebaseReflect.ts
@@ -8,13 +8,13 @@ import {
 } from "firebase/firestore";
 
 // 회고 등록 함수
-export const addReflect = async (user_id: number, content: string) => {
+export const addReflect = async (userId: number, content: string) => {
   try {
     const docRef = await addDoc(
-      collection(doc(database, "reflects", user_id.toString()), "posts"),
+      collection(doc(database, "reflects", userId.toString()), "posts"),
       {
         content,
-        created_at: serverTimestamp(),
+        createdAt: serverTimestamp(),
       }
     );
 
@@ -25,10 +25,10 @@ export const addReflect = async (user_id: number, content: string) => {
 };
 
 // 회고 조회 함수
-export const getReflect = async (user_id: number) => {
+export const getReflect = async (userId: number) => {
   try {
     const querySnapshot = await getDocs(
-      collection(doc(database, "reflects", user_id.toString()), "posts")
+      collection(doc(database, "reflects", userId.toString()), "posts")
     );
     const reflects = querySnapshot.docs.map((doc) => ({
       id: doc.id,

--- a/src/router/routerCategory.ts
+++ b/src/router/routerCategory.ts
@@ -3,21 +3,33 @@ import { addCategory, getCategories } from "../firebase/firebaseCategory";
 
 const router = Router();
 
-router.post("/todo/category/:userId", async (req, res) => {
-  const { categoryName, color } = req.body;
-  const { userId } = req.params;
+router.post("/todo/category", async (req, res) => {
+  const userId = req.session.userData?._id;
+  const { categoryName, textColor } = req.body;
+
+  if (!userId) {
+    res.status(401).send("로그인이 필요합니다.");
+    return;
+  }
 
   try {
-    const categoryId = await addCategory(userId, categoryName, color);
+    const categoryId = await addCategory(userId, categoryName, textColor);
     res.status(201).json({ message: "카테고리가 추가되었습니다.", categoryId });
   } catch (error: any) {
     res.status(500).send(error.message);
   }
 });
 
-router.get("/todo/category/:userId", async (req, res) => {
+router.get("/todo/category", async (req, res) => {
+  const userId = req.session.userData?._id;
+
+  if (!userId) {
+    res.status(401).send("로그인이 필요합니다.");
+    return;
+  }
+
   try {
-    const categories = await getCategories();
+    const categories = await getCategories(userId);
     res.status(200).json(categories);
   } catch (error: any) {
     res.status(500).send(error.message);


### PR DESCRIPTION
## ✅ 체크리스트

- [x]  카테고리 API 사용자 아이디 기반으로 데이터 구조 리팩토링
- [x]  변수명 통일

## 📝 작업 상세 내용

- Firestore에서 사용자별 카테고리를 관리할 수 있도록 데이터 구조 변경
- 공통된 변수명 통일

## 🚨 버그 발생 이유 (선택 사항)

## 🔎 후속 작업 (선택 사항)

## 🤔 질문 사항 (선택 사항)

## 📚 참고 자료 (선택 사항)

추가적인 참고 사항이나 관련된 문서, 링크 등을 제공해주세요.

## 📸 스크린샷 (선택 사항)
![image](https://github.com/user-attachments/assets/abbf8852-aafb-4ddf-9338-519480500b42)
![image](https://github.com/user-attachments/assets/6a874a81-cb70-4fd3-bf6a-0c0cf715492c)


## ✅ 셀프 체크리스트

- [x]  브랜치 확인하기
- [x]  불필요한 코드가 들어가지 않았는지 재확인하기
- [x]  issue 닫기
- [x]  reviewers, assignees, Lables 등록 확인하기

**이슈 번호**: #17 