### PR TITLE
[FEAT] feat: 회고 등록 시 이모지 저장 기능 추가

### DIFF
--- a/src/firebase/firebaseReflect.ts
+++ b/src/firebase/firebaseReflect.ts
@@ -8,12 +8,17 @@ import {
 } from "firebase/firestore";
 
 // 회고 등록 함수
-export const addReflect = async (userId: number, content: string) => {
+export const addReflect = async (
+  userId: number,
+  content: string,
+  emoji: string
+) => {
   try {
     const docRef = await addDoc(
       collection(doc(database, "reflects", userId.toString()), "posts"),
       {
         content,
+        emoji,
         createdAt: serverTimestamp(),
       }
     );

--- a/src/router/routerReflect.ts
+++ b/src/router/routerReflect.ts
@@ -13,11 +13,6 @@ router.post("/timecapsule/reflect", async (req, res) => {
     return;
   }
 
-  if (!content || !emoji) {
-    res.status(400).send("내용과 이모지를 모두 입력해야 합니다.");
-    return;
-  }
-
   try {
     const reflectId = await addReflect(userId, content, emoji);
     res.status(201).send(`회고가 등록되었습니다. ID: ${reflectId}`);

--- a/src/router/routerReflect.ts
+++ b/src/router/routerReflect.ts
@@ -6,15 +6,20 @@ const router = Router();
 // 회고 등록 엔드포인트
 router.post("/timecapsule/reflect", async (req, res) => {
   const userId = req.session.userData?._id; // 세션에서 사용자 ID 가져옴
-  const { content } = req.body;
+  const { content, emoji } = req.body;
 
   if (!userId) {
     res.status(401).send("로그인이 필요합니다.");
     return;
   }
 
+  if (!content || !emoji) {
+    res.status(400).send("내용과 이모지를 모두 입력해야 합니다.");
+    return;
+  }
+
   try {
-    const reflectId = await addReflect(userId, content);
+    const reflectId = await addReflect(userId, content, emoji);
     res.status(201).send(`회고가 등록되었습니다. ID: ${reflectId}`);
   } catch (error: any) {
     res.status(500).send(error.message);


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 회고 등록 시 이모지 저장 기능 추가

## 📝 작업 상세 내용

회고 등록 할 때 기존에는 내용만 DB에 저장되었으나 이모지도 함께 저장되도록 구현

## 🚨 버그 발생 이유 (선택 사항)

## 🔎 후속 작업 (선택 사항)

## 🤔 질문 사항 (선택 사항)

## 📚 참고 자료 (선택 사항)

추가적인 참고 사항이나 관련된 문서, 링크 등을 제공해주세요.

## 📸 스크린샷 (선택 사항)

변경 사항에 대한 스크린샷이 있다면 첨부해주세요.

## ✅ 셀프 체크리스트

- [x] 브랜치 확인하기
- [x] 불필요한 코드가 들어가지 않았는지 재확인하기
- [x] issue 닫기
- [x] reviewers, assignees, Lables 등록 확인하기

**이슈 번호**: #22 
