### PR TITLE
[FEAT] feat: 타임캡슐 읽기 가능 날짜 설정 구현

### DIFF
--- a/src/firebase/firebaseLetter.ts
+++ b/src/firebase/firebaseLetter.ts
@@ -5,17 +5,23 @@ import {
   getDocs,
   serverTimestamp,
   doc,
+  Timestamp,
 } from "firebase/firestore";
 
 // 편지 등록 함수
 export const addLetter = async (userId: number, content: string) => {
   try {
+    const now = new Date();
+    const nextYear = now.getFullYear() + 1;
+    const currentMonth = now.getMonth();
+    const canReadDate = new Date(nextYear, currentMonth, 1);
+
     const docRef = await addDoc(
       collection(doc(database, "letters", userId.toString()), "posts"),
       {
         content,
-        is_read: false,
         createdAt: serverTimestamp(),
+        canReadDate: Timestamp.fromDate(canReadDate),
       }
     );
 


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 타임캡슐 읽기 가능 날짜 설정 구현

## 📝 작업 상세 내용

- 편지를 작성할 때 읽기 가능한 날짜(`canReadDate`)를 현재 날짜 기준으로 1년 후로 설정하는 로직을 추가.
- 해당 날짜는 DB에 `canReadDate` 필드로 저장해서 1년 후에 편지를 열 수 있도록 함.

## 🚨 버그 발생 이유 (선택 사항)

## 🔎 후속 작업 (선택 사항)

## 🤔 질문 사항 (선택 사항)

## 📚 참고 자료 (선택 사항)

추가적인 참고 사항이나 관련된 문서, 링크 등을 제공해주세요.

## 📸 스크린샷 (선택 사항)

변경 사항에 대한 스크린샷이 있다면 첨부해주세요.

## ✅ 셀프 체크리스트

- [x] 브랜치 확인하기
- [x] 불필요한 코드가 들어가지 않았는지 재확인하기
- [x] issue 닫기
- [x] reviewers, assignees, Lables 등록 확인하기

**이슈 번호**: #26 
