### PR TITLE
[FEAT] feat: 카카오 로그아웃 API 구현

### DIFF
--- a/src/config/sessionConfig.ts
+++ b/src/config/sessionConfig.ts
@@ -2,7 +2,12 @@ import session from "express-session";
 
 declare module "express-session" {
   interface SessionData {
-    userData: { _id: number; name: string; profileImage: string };
+    userData: {
+      _id: number;
+      name: string;
+      profileImage: string;
+      accessToken: string;
+    };
   }
 }
 

--- a/src/router/kakaoRoutes.ts
+++ b/src/router/kakaoRoutes.ts
@@ -79,3 +79,30 @@ kakaoRouter.get("/api/user", async (req: Request, res: Response) => {
     res.status(500).json({ e: "사용자 조회 실패" });
   }
 });
+
+/* 카카오 로그아웃 API */
+kakaoRouter.post("/api/logout", async (req: any, res: any) => {
+  const accessToken = req.session.userData?.accessToken;
+
+  if (!accessToken) {
+    return res.status(401).json({ error: "로그인 상태가 아닙니다." });
+  }
+
+  try {
+    await axios({
+      method: "POST",
+      url: "https://kapi.kakao.com/v1/user/logout",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+
+    delete req.session.userData;
+    await req.session.save();
+
+    res.status(200).json({ message: "로그아웃 성공" });
+  } catch (e: any) {
+    console.log(e);
+    res.status(500).json({ error: "로그아웃 실패" });
+  }
+});

--- a/src/router/kakaoRoutes.ts
+++ b/src/router/kakaoRoutes.ts
@@ -34,9 +34,9 @@ kakaoRouter.get(
           code: req.query.code as string,
         }),
       });
-    } catch (e: any) {
-      res.json(e.data);
-      return;
+    } catch (error: any) {
+      console.error("토근을 불러올 수 없습니다.", error);
+      return res.status(400).json({ error: "토큰 발급 실패" });
     }
 
     /* access token 발급받은 뒤 사용자 정보 가져옴 */
@@ -49,9 +49,9 @@ kakaoRouter.get(
           Authorization: `Bearer ${token.data.access_token}`,
         },
       });
-    } catch (e: any) {
-      res.json(e.data);
-      return;
+    } catch (error: any) {
+      console.error("유저 데이터를 불러올 수 없습니다.", error);
+      return res.status(400).json({ error: "사용자 정보 조회 실패" });
     }
 
     /* 가지고 온 사용자 정보 DB & session 저장 */

--- a/src/router/kakaoRoutes.ts
+++ b/src/router/kakaoRoutes.ts
@@ -61,6 +61,7 @@ kakaoRouter.get(
       _id: user.data.id,
       name: user.data.kakao_account.profile.nickname,
       profileImage: user.data.kakao_account.profile.profile_image_url,
+      accessToken: token.data.access_token,
     };
 
     await req.session.save(); // 세션 저장

--- a/src/router/kakaoRoutes.ts
+++ b/src/router/kakaoRoutes.ts
@@ -30,7 +30,7 @@ kakaoRouter.get(
         data: qs.stringify({
           grant_type: "authorization_code",
           client_id: kakao.CLIENT_ID,
-          redirectUri: kakao.REDIRECT_URI,
+          redirect_uri: kakao.REDIRECT_URI,
           code: req.query.code as string,
         }),
       });


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 카카오 로그아웃 API 구현 `/api/logout`

## 📝 작업 상세 내용

> `/api/logout`으로 요청 시 현재 로그인된 사용자의 세션 데이터가 모두 삭제되며 로그아웃이 완료됩니다.

> 액세스 토큰을 카카오 측에서 받아오고 있지만 세션에는 저장되고 있지 않아 세션 데이터에 액세스 토큰을 추가해 주었습니다.

```ts
    req.session.userData = {
      _id: user.data.id,
      name: user.data.kakao_account.profile.nickname,
      profileImage: user.data.kakao_account.profile.profile_image_url,
      accessToken: token.data.access_token, // 추가된 부분 
    };
```

## 🚨 버그 발생 이유 (선택 사항)

## 🔎 후속 작업 (선택 사항)

## 🤔 질문 사항 (선택 사항)

## 📚 참고 자료 (선택 사항)

[[NodeJS] Kakao REST APIs 활용한 로그인, 로그아웃, 사용자 정보 가져오기, 연결해제](https://velog.io/@kon6443/NodeJS-Kakao-REST-APIs-%ED%99%9C%EC%9A%A9%ED%95%9C-%EB%A1%9C%EA%B7%B8%EC%9D%B8-%EB%A1%9C%EA%B7%B8%EC%95%84%EC%9B%83-%EC%82%AC%EC%9A%A9%EC%9E%90-%EC%A0%95%EB%B3%B4-%EA%B0%80%EC%A0%B8%EC%98%A4%EA%B8%B0-%EC%97%B0%EA%B2%B0%ED%95%B4%EC%A0%9C)
[[Node.js]카카오 회원 탈퇴, 로컬 로그인/로그아웃 만들기](https://velog.io/@nara7875/Node.js%EC%B9%B4%EC%B9%B4%EC%98%A4-%ED%9A%8C%EC%9B%90-%ED%83%88%ED%87%B4-%EB%A1%9C%EC%BB%AC-%EB%A1%9C%EA%B7%B8%EC%9D%B8%EB%A1%9C%EA%B7%B8%EC%95%84%EC%9B%83-%EB%A7%8C%EB%93%A4%EA%B8%B0)

## 📸 스크린샷 (선택 사항)

변경 사항에 대한 스크린샷이 있다면 첨부해주세요.

## ✅ 셀프 체크리스트

- [x] 브랜치 확인하기
- [x] 불필요한 코드가 들어가지 않았는지 재확인하기
- [x] issue 닫기
- [x] reviewers, assignees, Lables 등록 확인하기

**이슈 번호**: #29 
